### PR TITLE
Schedule Proposal

### DIFF
--- a/SCHEDULE.md
+++ b/SCHEDULE.md
@@ -1,0 +1,38 @@
+IPFS Workshop Schedule
+======================
+
+## Day 1
+
+> Get everyone psyched with IPFS, IPLD and libp2p. Get in depth understanding through hands on hacking.
+
+| Time   | Type     | Session                    | Speaker
+|:-------|:---------|:---------------------------|:-------
+| 10:00h | --       | people arrive and set up   | --
+| 10:15h | talk     | welcome presentation       | Juan or David
+| 10:30h | talk     | The State of IPFS          | Juan
+| 11:30h | talk     | IPLD                       | Juan
+| 12:15h | talk     | libp2p                     | David and Jeromy
+| 13:00h | open     | Lunch Break                | --
+| 14:15h | workshop | go-ipfs hands on           | Jeromy
+| 15:30h | workshop | IPLD hands on              | Juan and Friedel(remote)
+| 16:45h | workshop | libp2p hands on            | David and Jeromy
+| 18:00h | --       | end of day 1               | --
+
+## Day 2
+
+> Remaining presentations (js-ipfs, orbit, infrastructure and documentation), idea lightround`*`, community presentations, open hack time, hack showcase and sum up of the workshop.
+
+| Time   | Type     | Session                    | Speaker
+|:-------|:---------|:---------------------------|:-------
+| 10:00h | --       | people arrive and set up   | --
+| 10:10h | talk     | js-ipfs                    | David
+| 10:20h | talk     | orbit and orbit-db         | Samuli
+| 10:40h | talk     | Infrastructure             | Lars
+| 11:00h | talk     | Documentation              | Richard(remote)
+| 11:20h | open     | FREE SESSIONS              | Sign up! :)
+| 13:30h | open     | Lunch Break                | --
+| 14:30h | --       | Open Hacking Time          | --
+| 17:00h | open     | Sum up, hacks showcase     | --
+| 18:00h | --       | end of day 2               | --
+
+`*` idea lightround will be a session for IPFS contributors and enthusiasts to share one idea in under 2 minutes of what they want to implement with IPFS.

--- a/SCHEDULE.md
+++ b/SCHEDULE.md
@@ -3,36 +3,32 @@ IPFS Workshop Schedule
 
 ## Day 1
 
-> Get everyone psyched with IPFS, IPLD and libp2p. Get in depth understanding through hands on hacking.
+> Get everyone psyched with IPFS, IPLD and libp2p. Showcase of current projects using IPFS.
 
-| Time   | Type     | Session                    | Speaker
-|:-------|:---------|:---------------------------|:-------
-| 10:00h | --       | people arrive and set up   | --
-| 10:15h | talk     | welcome presentation       | Juan or David
-| 10:30h | talk     | The State of IPFS          | Juan
-| 11:30h | talk     | IPLD                       | Juan
-| 12:15h | talk     | libp2p                     | David and Jeromy
-| 13:00h | open     | Lunch Break                | --
-| 14:15h | workshop | go-ipfs hands on           | Jeromy
-| 15:30h | workshop | IPLD hands on              | Juan and Friedel(remote)
-| 16:45h | workshop | libp2p hands on            | David and Jeromy
-| 18:00h | --       | end of day 1               | --
+| Time   | Type       | Session                            | Speaker
+|:-------|:-----------|:-----------------------------------|:-------
+| 10:00h | --         | People arrive and set up           | --
+| 10:15h | talk       | Welcome to the IPFS Workshop       | Juan and David
+| 10:30h | talk       | The State of IPFS, IPLD and libp2p | Juan
+| 11:15h | talk       |                                    | --
+| 11:30h | talk       | Rapid Fire Projects Showcase       | Juan
+| 12:30h | open       | Lunch Break                        | --
+| 14:00h | discussion | Problem Solving Sessions           | --
+| 18:00h | --         | end of day 1                       | --
 
 ## Day 2
 
-> Remaining presentations (js-ipfs, orbit, infrastructure and documentation), idea lightround`*`, community presentations, open hack time, hack showcase and sum up of the workshop.
+> Guest presentations, idea lightround`*`, open hack time, hack showcase and sum up of the workshop.
 
 | Time   | Type     | Session                    | Speaker
 |:-------|:---------|:---------------------------|:-------
 | 10:00h | --       | people arrive and set up   | --
-| 10:10h | talk     | js-ipfs                    | David
-| 10:20h | talk     | orbit and orbit-db         | Samuli
-| 10:40h | talk     | Infrastructure             | Lars
-| 11:00h | talk     | Documentation              | Richard(remote)
-| 11:20h | open     | FREE SESSIONS              | Sign up! :)
-| 13:30h | open     | Lunch Break                | --
-| 14:30h | --       | Open Hacking Time          | --
-| 17:00h | open     | Sum up, hacks showcase     | --
+| 10:10h | talk     | Futuristic Connectivity    | Lars
+| 10:20h | talk     | IPFS Infrastructure        | Lars
+| 10:40h | talk     | Orbit and Orbit-db         | Samuli
+| 11:00h | talk     | Guest presenatations       | Sign up! :)
+| 12:30h | open     | Lunch Break                | --
+| 14:00h | --       | Open Hacking Time          | --
 | 18:00h | --       | end of day 2               | --
 
 `*` idea lightround will be a session for IPFS contributors and enthusiasts to share one idea in under 2 minutes of what they want to implement with IPFS.


### PR DESCRIPTION
Me and @whyrusleeping went ahead and prepared a schedule proposal for the IPFS Workshop, to give some structure and define expectations for this event.

The main idea with the proposed schedule is getting everyone up to speed with the current endeavours on the IPFS project during the mornings and hands on/hacking session on the afternoons where the leads of the project can guide the attendees on how to use each project and discuss its roadmap and where the community can contribute.

On the second day, we also have time allocated for community presentations (for anyone that wants to volunteer) and a very fun session, `idea lightround`, where everyone gets 2 minutes to present a project they want to develop with IPFS.

**Next:**
- [ ] Review the proposal (@jbenet @em-ly)
- [ ] Create an issue for each of the sessions with description, goal and outcomes
- [ ] Accept proposals for the free sessions on Day 2
